### PR TITLE
feat: add plugin for flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ If you wish to use pre-commit, add this:
       - id: tryceratops
 ```
 
+## [`flake8`](https://github.com/PyCQA/flake8) Plugin
+
+🦖 Tryceratops is also a plugin for `flake8`, so you can:
+
+```
+❯ flake8 --select TC src/tests/samples/violations/call_raise_vanilla.py
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
+src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
+```
+
 ### Configuration
 
 You can set up a `pyproject.toml` file to set rules.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ I shared [the building process of this tool here](https://blog.guilatrova.dev/pr
 
 > “For those who like dinosaurs 🦖 and clean try/except ✨ blocks.”
 
+- [Installation and usage](#installation-and-usage)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [`flake8` Plugin](#flake8-plugin)
+- [Violations](#violations)
+  - [Ignoring violations](#ignoring-violations)
+  - [Configuration](#configuration)
+- [Pre-commit](#pre-commit)
+- [License](#license)
+- [Credits](#credits)
+
 ---
 
 ## Installation and usage
@@ -60,6 +71,17 @@ tryceratops --exclude tests --exclude .venv [filename or dir...]
 
 ![example](https://raw.githubusercontent.com/guilatrova/tryceratops/main/img/tryceratops-example2.gif)
 
+### [`flake8`](https://github.com/PyCQA/flake8) Plugin
+
+🦖 Tryceratops is also a plugin for `flake8`, so you can:
+
+```
+❯ flake8 --select TC src/tests/samples/violations/call_raise_vanilla.py
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
+src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
+```
+
 ## Violations
 
 All violations and its descriptions can be found in [docs](https://github.com/guilatrova/tryceratops/tree/main/docs/violations).
@@ -82,28 +104,6 @@ def verbose_reraise_1():
         raise ex  # notc: TC202
 ```
 
-## Pre-commit
-
-If you wish to use pre-commit, add this:
-
-```yaml
-  - repo: https://github.com/guilatrova/tryceratops
-    rev: v0.2.3
-    hooks:
-      - id: tryceratops
-```
-
-## [`flake8`](https://github.com/PyCQA/flake8) Plugin
-
-🦖 Tryceratops is also a plugin for `flake8`, so you can:
-
-```
-❯ flake8 --select TC src/tests/samples/violations/call_raise_vanilla.py
-src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
-src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
-src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
-```
-
 ### Configuration
 
 You can set up a `pyproject.toml` file to set rules.
@@ -119,6 +119,17 @@ experimental = true
 ```
 
 CLI flags always overwrite the config file.
+
+## Pre-commit
+
+If you wish to use pre-commit, add this:
+
+```yaml
+  - repo: https://github.com/guilatrova/tryceratops
+    rev: v0.2.3
+    hooks:
+      - id: tryceratops
+```
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ test = [
 [tool.flit.entrypoints.console_scripts]
 tryceratops = "tryceratops.__main__:main"
 
+[tool.flit.entrypoints."flake8.extension"]
+TC = "tryceratops.flake_plugin:TryceratopsAdapterPlugin"
+
 [tool.black]
 line-length = 100
 

--- a/src/tryceratops/flake_plugin.py
+++ b/src/tryceratops/flake_plugin.py
@@ -4,6 +4,7 @@ from tokenize import TokenInfo
 from typing import Any, Generator, Iterable, List, Tuple, Type
 
 from tryceratops.analyzers.main import Runner
+from tryceratops.files.discovery import load_config
 from tryceratops.files.parser import parse_ignore_tokens
 from tryceratops.filters import FileFilter, GlobalFilter
 from tryceratops.violations.violations import Violation
@@ -30,6 +31,14 @@ class TryceratopsAdapterPlugin:
 
         ignore_lines = list(parse_ignore_tokens(file_tokens))
         self._file_filter = FileFilter(ignore_lines)
+        self._global_filter = self._create_global_filter(filename)
+
+    def _create_global_filter(self, filename: str) -> GlobalFilter:
+        pyproj_config = load_config([filename])
+        if pyproj_config:
+            return GlobalFilter.create_from_config(pyproj_config)
+
+        return GLOBAL_DUMMY_FILTER
 
     def _execute_analyzer(self) -> List[Violation]:
         tryceratops_input = [
@@ -39,7 +48,7 @@ class TryceratopsAdapterPlugin:
                 self._file_filter,
             )
         ]
-        return self._runner.analyze(tryceratops_input, GLOBAL_DUMMY_FILTER)
+        return self._runner.analyze(tryceratops_input, self._global_filter)
 
     def run(self) -> Generator[FLAKE8_VIOLATION_TYPE, None, None]:
         violations = self._execute_analyzer()

--- a/src/tryceratops/flake_plugin.py
+++ b/src/tryceratops/flake_plugin.py
@@ -1,0 +1,40 @@
+import ast
+import importlib.metadata
+from typing import Any, Generator, List, Tuple, Type
+
+from tryceratops.analyzers.main import Runner
+from tryceratops.filters import FileFilter, GlobalFilter
+from tryceratops.violations.violations import Violation
+
+PACKAGE_NAME = "tryceratops"
+DUMMY_FILE_FILTER = FileFilter([])
+# line, offset, message, class
+FLAKE8_VIOLATION_TYPE = Tuple[int, int, str, Type[Any]]
+
+
+class TryceratopsAdapterPlugin:
+    name = PACKAGE_NAME
+    version = importlib.metadata.version(PACKAGE_NAME)
+
+    def __init__(self, tree: ast.AST, filename: str = None):
+        self._runner = Runner()
+        self._global_filter = GlobalFilter(False, ignore_violations=[], exclude_dirs=[])
+        self._filename = filename
+        self._tree = tree
+
+    def _execute_analyzer(self) -> List[Violation]:
+        tryceratops_input = [
+            (
+                self._filename,
+                self._tree,
+                DUMMY_FILE_FILTER,
+            )
+        ]
+        return self._runner.analyze(tryceratops_input, self._global_filter)
+
+    def run(self) -> Generator[FLAKE8_VIOLATION_TYPE, None, None]:
+        violations = self._execute_analyzer()
+
+        for violation in violations:
+            msg = f"{violation.code} {violation.description}"
+            yield violation.line, violation.col, msg, type(self)


### PR DESCRIPTION
Steps:

- [x] Add flake8 entrypoint
- [x] Handle ignore comments
- [x] Handle `pyproject` config
- [x] Update docs

## Results

Running `flake8 --help`:

```
Installed plugins: mccabe: 0.6.1, pycodestyle: 2.7.0, pyflakes: 2.3.1, tryceratops: 0.2.3
```

Running `flake8` on file:

```
❯ flake8 src/tests/samples/violations/call_raise_vanilla.py
src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
src/tests/samples/violations/call_raise_vanilla.py:18:9: F841 local variable 'a' is assigned to but never used
src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
```

Running `flake8 --select`

```
❯ flake8 --select TC src/tests/samples/violations/call_raise_vanilla.py
src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
```