### PR TITLE
Fix #8

### DIFF
--- a/src/tryceratops/interfaces.py
+++ b/src/tryceratops/interfaces.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -66,6 +67,7 @@ class CliInterface:
         log_file_path = f"{cwd}/{ERROR_LOG_FILENAME}"
         is_log_empty = os.path.getsize(log_file_path) == 0
 
+        logging.shutdown()
         if is_log_empty:
             os.remove(log_file_path)
 


### PR DESCRIPTION
This fixes issue #8 by calling the `logging.shutdown` function: https://docs.python.org/3/library/logging.html#logging.shutdown

As per the docs,

 > Informs the logging system to perform an orderly shutdown by flushing and closing all handlers. This should be called at application exit and no further use of the logging system should be made after this call.
> 
>   When the logging module is imported, it registers this function as an exit handler (see atexit), so normally there’s no need to do that manually.

There might be a more appropriate place to insert this `.shutdown()` call, but it must be before the empty logs are deleted.