### PR TITLE
fix: shutdown logging on exit

### DIFF
--- a/src/tryceratops/interfaces.py
+++ b/src/tryceratops/interfaces.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -70,6 +71,7 @@ class CliInterface:
             os.remove(log_file_path)
 
     def present_and_exit(self):
+        logging.shutdown()
         self._present_violations()
         self._present_status()
         self._delete_empty_logs()


### PR DESCRIPTION
This closes #8 by shutting down `logging` when `tryceratops` is exiting, freeing up the resources in use, namely the log file that Windows didn't want to delete.