### PR TITLE
Fix: Tolerate and present discovery issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ line-length = 100
 [tool.isort]
 profile = "black"
 line_length = 100
-extra_standard_library = "pytest"
+extra_standard_library = ["pytest", "toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ line-length = 100
 [tool.isort]
 profile = "black"
 line_length = 100
-extra_standard_library = ["pytest", "toml"]
+extra_standard_library = ["pytest", "toml", "click"]

--- a/src/tryceratops/__main__.py
+++ b/src/tryceratops/__main__.py
@@ -4,14 +4,14 @@ from typing import Tuple
 
 import tryceratops
 from tryceratops.analyzers import Runner
-from tryceratops.files import parse_python_files
-from tryceratops.files.discovery import load_config
+from tryceratops.files import FileDiscovery, load_config
 from tryceratops.filters import GlobalFilter
 from tryceratops.interfaces import CliInterface
 from tryceratops.settings import LOGGING_CONFIG
 from tryceratops.violations import CODE_CHOICES
 
 runner = Runner()
+discovery = FileDiscovery()
 interface = CliInterface(runner)
 
 
@@ -40,7 +40,7 @@ def entrypoint(
     else:
         global_filter = GlobalFilter(experimental, ignore, exclude)
 
-    parsed_files = list(parse_python_files(dir))
+    parsed_files = list(discovery.parse_python_files(dir))
     runner.analyze(parsed_files, global_filter)
 
     interface.present_and_exit()

--- a/src/tryceratops/__main__.py
+++ b/src/tryceratops/__main__.py
@@ -12,7 +12,7 @@ from tryceratops.violations import CODE_CHOICES
 
 runner = Runner()
 discovery = FileDiscovery()
-interface = CliInterface(runner)
+interface = CliInterface(runner, discovery)
 
 
 EXPERIMENTAL_FLAG_OPTION = dict(is_flag=True, help="Whether to enable experimental analyzers.")

--- a/src/tryceratops/__main__.py
+++ b/src/tryceratops/__main__.py
@@ -1,7 +1,6 @@
+import click
 import logging.config
 from typing import Tuple
-
-import click
 
 import tryceratops
 from tryceratops.analyzers import Runner

--- a/src/tryceratops/files/__init__.py
+++ b/src/tryceratops/files/__init__.py
@@ -1,1 +1,1 @@
-from .discovery import parse_python_files
+from .discovery import FileDiscovery, load_config

--- a/src/tryceratops/files/discovery.py
+++ b/src/tryceratops/files/discovery.py
@@ -1,9 +1,8 @@
+import toml
 from os import listdir
 from os.path import isdir, isfile, join
 from pathlib import Path
 from typing import Generator, Iterable, Optional, Sequence, Tuple
-
-import toml
 
 from tryceratops.types import ParsedFileType, PyprojectConfig
 

--- a/src/tryceratops/files/parser.py
+++ b/src/tryceratops/files/parser.py
@@ -2,7 +2,7 @@ import ast
 import re
 import tokenize
 from io import TextIOWrapper
-from typing import Generator, Iterable, Optional, Tuple
+from typing import Generator, Iterable, Tuple
 
 from tryceratops.filters import FileFilter, IgnoreViolation
 
@@ -36,19 +36,15 @@ def parse_ignore_comments_from_file(
     yield from parse_ignore_tokens(tokens)
 
 
-def parse_tree(content: TextIOWrapper) -> Optional[ast.AST]:
-    try:
-        return ast.parse(content.read())
-    except Exception:
-        return None
+def parse_tree(content: TextIOWrapper) -> ast.AST:
+    return ast.parse(content.read())
 
 
-def parse_file(filename: str) -> Optional[Tuple[ast.AST, FileFilter]]:
+def parse_file(filename: str) -> Tuple[ast.AST, FileFilter]:
     with open(filename, "r") as content:
         tree = parse_tree(content)
-        if tree:
-            content.seek(0)
-            ignore_lines = list(parse_ignore_comments_from_file(content))
-            return tree, FileFilter(ignore_lines)
 
-        return None
+        content.seek(0)
+        ignore_lines = list(parse_ignore_comments_from_file(content))
+
+        return tree, FileFilter(ignore_lines)

--- a/src/tryceratops/interfaces.py
+++ b/src/tryceratops/interfaces.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from tryceratops.analyzers import Runner
+from tryceratops.files.discovery import FileDiscovery
 from tryceratops.settings import ERROR_LOG_FILENAME
 from tryceratops.violations import Violation
 
@@ -10,6 +11,7 @@ from tryceratops.violations import Violation
 class COLORS:
     DESCR = "\033[91m"
     CODE = "\033[93m"
+    ERROR = "\033[91m"
 
     ENDC = "\033[0m"
 
@@ -27,8 +29,9 @@ def present_violation(violation: Violation):
 
 
 class CliInterface:
-    def __init__(self, runner: Runner):
+    def __init__(self, runner: Runner, discovery: FileDiscovery):
         self.runner = runner
+        self.discovery = discovery
 
     def _present_violations(self):
         for violation in self.runner.violations:
@@ -42,6 +45,11 @@ class CliInterface:
             print(f"Found {len(self.runner.violations)} violations")
         else:
             print("Nothing to check!")
+
+        if self.discovery.had_issues:
+            print(
+                wrap_color(f"Failed to process {len(self.discovery.failures)} files", COLORS.ERROR)
+            )
 
         if self.runner.excluded_files:
             print(f"Skipped {self.runner.excluded_files} files")


### PR DESCRIPTION
Make tryceratops tolerant to bad python files (bad syntax, etc), like for example:

```py
def func():
    try:
        a = 1
    exc # <- Accidental line break, invalid python syntax
    ept:
        raise
```

### Before:

No response and just the stack trace described by https://github.com/guilatrova/tryceratops/issues/11

### Now:

Displays an error when found

![image](https://user-images.githubusercontent.com/14880710/126021660-a9ffb37e-d1c1-4705-9395-8b7dcced2442.png)
