### PR TITLE
feat!: rename 'notc' tokens to become 'noqa'

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ All violations and its descriptions can be found in [docs](https://github.com/gu
 
 If you want to ignore a violation in a specific file, you can either:
 
-- Add a comment with `notc` to the top of the file you want to ignore
-- Add a comment with `notc` to the line you want to ignore
-- Add a comment with `notc: CODE` to the line you want to ignore a specific violation
+- Add a comment with `noqa` to the top of the file you want to ignore
+- Add a comment with `noqa` to the line you want to ignore
+- Add a comment with `noqa: CODE` to the line you want to ignore a specific violation
 
 Example:
 
@@ -105,7 +105,7 @@ def verbose_reraise_1():
     try:
         a = 1
     except Exception as ex:
-        raise ex  # notc: TC202
+        raise ex  # noqa: TC202
 ```
 
 ### Configuration

--- a/src/tests/samples/ignore_comments/ignore_file.py
+++ b/src/tests/samples/ignore_comments/ignore_file.py
@@ -1,4 +1,4 @@
-# notc
+# noqa
 class MyException(Exception):
     pass
 
@@ -24,7 +24,7 @@ def verbose_reraise_2():
 
 def too_many_try():
     try:
-        a = 1  # notc <- it doesnt matter because I ignored the whole file
+        a = 1  # noqa <- it doesnt matter because I ignored the whole file
     except Exception:
         raise
 

--- a/src/tests/samples/ignore_comments/ignore_line.py
+++ b/src/tests/samples/ignore_comments/ignore_line.py
@@ -10,7 +10,7 @@ def verbose_reraise_1():
     except (NotImplementedError, ValueError) as ex:
         raise
     except Exception as ex:
-        raise ex  # notc
+        raise ex  # noqa
 
 
 def verbose_reraise_2():
@@ -18,7 +18,7 @@ def verbose_reraise_2():
         a = 1
     except Exception as ex:
         if a == 1:
-            raise ex  # notc
+            raise ex  # noqa
 
 
 def too_many_try():
@@ -27,7 +27,7 @@ def too_many_try():
     except Exception:
         raise
 
-    try:  # notc
+    try:  # noqa
         b = 2
     except Exception:
         raise

--- a/src/tests/samples/ignore_comments/ignore_line_specific.py
+++ b/src/tests/samples/ignore_comments/ignore_line_specific.py
@@ -10,7 +10,7 @@ def verbose_reraise_1():
     except (NotImplementedError, ValueError) as ex:
         raise
     except Exception as ex:
-        raise ex  # notc: TC202
+        raise ex  # noqa: TC202
 
 
 def verbose_reraise_2():
@@ -18,7 +18,7 @@ def verbose_reraise_2():
         a = 1
     except Exception as ex:
         if a == 1:
-            raise ex  # notc: TC202, TC200, TC201 I want to skip
+            raise ex  # noqa: TC202, TC200, TC201 I want to skip
 
 
 def too_many_try():
@@ -27,7 +27,7 @@ def too_many_try():
     except Exception:
         raise
 
-    try:  # notc:TC101 this is not a big deal
+    try:  # noqa:TC101 this is not a big deal
         b = 2
     except Exception:
         raise

--- a/src/tryceratops/files/parser.py
+++ b/src/tryceratops/files/parser.py
@@ -5,8 +5,8 @@ from typing import Generator, Iterable, TextIO, Tuple
 
 from tryceratops.filters import FileFilter, IgnoreViolation
 
-IGNORE_TRYCERATOPS_TOKEN = "notc"
-IGNORE_TOKEN_PATT = r"notc(: ?((TC\d{3},? ?)+))?"
+IGNORE_TRYCERATOPS_TOKEN = "noqa"
+IGNORE_TOKEN_PATT = r"noqa(: ?((TC\d{3},? ?)+))?"
 
 
 def _build_ignore_line(match: re.Match, location: Tuple[int, int]) -> IgnoreViolation:


### PR DESCRIPTION
BREAKING CHANGE: Any previous 'notc' token will stop working. Now you must use 'noqa' instead, which keeps consistent with flake8 standards.

On this issue https://github.com/guilatrova/tryceratops/issues/15 there's a longer clarification.