### PR TITLE
feat: changed flake8 code from TC to TRY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 *.egg-info
 *.pyc
 *.log

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ You can enable experimental analyzers by running:
 tryceratops --experimental [filename or dir...]
 ```
 
-You can ignore specific violations by using: `--ignore TCXXX` repeatedly:
+You can ignore specific violations by using: `--ignore TRYXXX` repeatedly:
 
 ```
-tryceratops --ignore TC201 --ignore TC202 [filename or dir...]
+tryceratops --ignore TRY201 --ignore TRY202 [filename or dir...]
 ```
 
 You can exclude dirs by using: `--exclude dir/path` repeatedly:
@@ -90,10 +90,10 @@ tryceratops --autofix [filename or dir...]
 🦖 Tryceratops is also a plugin for `flake8`, so you can:
 
 ```
-❯ flake8 --select TC src/tests/samples/violations/call_raise_vanilla.py
-src/tests/samples/violations/call_raise_vanilla.py:13:9: TC002 Create your own exception
-src/tests/samples/violations/call_raise_vanilla.py:13:9: TC003 Avoid specifying long messages outside the exception class
-src/tests/samples/violations/call_raise_vanilla.py:21:9: TC201 Simply use 'raise' without specifying exception object again
+❯ flake8 --select TRY src/tests/samples/violations/call_raise_vanilla.py
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TRY002 Create your own exception
+src/tests/samples/violations/call_raise_vanilla.py:13:9: TRY003 Avoid specifying long messages outside the exception class
+src/tests/samples/violations/call_raise_vanilla.py:21:9: TRY201 Simply use 'raise' without specifying exception object again
 ```
 
 ## Violations
@@ -102,7 +102,7 @@ All violations and its descriptions can be found in [docs](https://github.com/gu
 
 ### Autofix support
 
-So far, autofix only supports violations: [TC200](docs/violations/TC200.md), [TC201](docs/violations/TC201.md), and [TC400](docs/violations/TC400.md).
+So far, autofix only supports violations: [TRY200](docs/violations/TRY200.md), [TRY201](docs/violations/TRY201.md), and [TRY400](docs/violations/TRY400.md).
 
 ### Ignoring violations
 
@@ -119,7 +119,7 @@ def verbose_reraise_1():
     try:
         a = 1
     except Exception as ex:
-        raise ex  # noqa: TC202
+        raise ex  # noqa: TRY202
 ```
 
 ### Configuration
@@ -132,7 +132,7 @@ Example:
 ```toml
 [tool.tryceratops]
 exclude = ["samples"]
-ignore = ["TC002", "TC200", "TC300"]
+ignore = ["TRY002", "TRY200", "TRY300"]
 experimental = true
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,9 +50,9 @@ or test it against some violation files we have in place:
 
 ```sh
 ❯ poetry run tryceratops src/tests/samples/violations/call_too_many_try.py
-[TC101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:15:4
-[TC101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:27:4
-[TC101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:32:4
+[TRY101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:15:4
+[TRY101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:27:4
+[TRY101] Too many try blocks in your function - src/tests/samples/violations/call_too_many_try.py:32:4
 Done processing! 🦖✨
 Processed 1 files
 Found 3 violations
@@ -61,10 +61,10 @@ Found 3 violations
 You can try it with flake8 if preferred:
 
 ```sh
-❯ poetry run flake8 --select TC src/tests/samples/violations/call_too_many_try.py
-src/tests/samples/violations/call_too_many_try.py:15:5: TC101 Too many try blocks in your function
-src/tests/samples/violations/call_too_many_try.py:27:5: TC101 Too many try blocks in your function
-src/tests/samples/violations/call_too_many_try.py:32:5: TC101 Too many try blocks in your function
+❯ poetry run flake8 --select TRY src/tests/samples/violations/call_too_many_try.py
+src/tests/samples/violations/call_too_many_try.py:15:5: TRY101 Too many try blocks in your function
+src/tests/samples/violations/call_too_many_try.py:27:5: TRY101 Too many try blocks in your function
+src/tests/samples/violations/call_too_many_try.py:32:5: TRY101 Too many try blocks in your function
 ```
 
 ## Linting

--- a/docs/violations/README.md
+++ b/docs/violations/README.md
@@ -1,43 +1,43 @@
 # Violations
 
-## `TC0xx` - Exception Classes
+## `TRY0xx` - Exception Classes
 
 
 | Code              | Description                                                |
 | ----------------- | ---------------------------------------------------------- |
-| [TC002](TC002.md) | Create your own exception                                  |
-| [TC003](TC003.md) | Avoid specifying long messages outside the exception class |
-| [TC004](TC004.md) | Prefer `TypeError` exception for invalid type              |
+| [TRY002](TRY002.md) | Create your own exception                                  |
+| [TRY003](TRY003.md) | Avoid specifying long messages outside the exception class |
+| [TRY004](TRY004.md) | Prefer `TypeError` exception for invalid type              |
 
-## `TC1xx` - General
+## `TRY1xx` - General
 
 
 | Code                                 | Description           |
 | ------------------------------------ | --------------------- |
-| [TC100](TC100.md) (**EXPERIMENTAL**) | Check to continue     |
-| [TC101](TC101.md)                    | Too many `try` blocks |
+| [TRY100](TRY100.md) (**EXPERIMENTAL**) | Check to continue     |
+| [TRY101](TRY101.md)                    | Too many `try` blocks |
 
-## `TC2xx` - Except blocks
+## `TRY2xx` - Except blocks
 
 
 | Code              | Description                                         |
 | ----------------- | --------------------------------------------------- |
-| [TC200](TC200.md) | Use `raise Exception from`                          |
-| [TC201](TC201.md) | Simply use `raise`                                  |
-| [TC202](TC202.md) | Don't ignore a broad exception without even logging |
+| [TRY200](TRY200.md) | Use `raise Exception from`                          |
+| [TRY201](TRY201.md) | Simply use `raise`                                  |
+| [TRY202](TRY202.md) | Don't ignore a broad exception without even logging |
 
-## `TC3xx` - Try blocks
+## `TRY3xx` - Try blocks
 
 
 | Code              | Description                       |
 | ----------------- | --------------------------------- |
-| [TC300](TC300.md) | Consider adding an `else` block   |
-| [TC301](TC301.md) | Avoid direct raises in `try` body |
+| [TRY300](TRY300.md) | Consider adding an `else` block   |
+| [TRY301](TRY301.md) | Avoid direct raises in `try` body |
 
-## `TC4xx` - Logging usage
+## `TRY4xx` - Logging usage
 
 
 | Code              | Description                                  |
 | ----------------- | -------------------------------------------- |
-| [TC400](TC400.md) | Use logging `.exception` instead of `.error` |
-| [TC401](TC401.md) | Do not log the exception object              |
+| [TRY400](TRY400.md) | Use logging `.exception` instead of `.error` |
+| [TRY401](TRY401.md) | Do not log the exception object              |

--- a/docs/violations/TRY002.md
+++ b/docs/violations/TRY002.md
@@ -1,4 +1,4 @@
-# `TC002` - Create your own exception
+# `TRY002` - Create your own exception
 
 ## Why is it bad
 

--- a/docs/violations/TRY003.md
+++ b/docs/violations/TRY003.md
@@ -1,4 +1,4 @@
-# `TC003` - Avoid specifying messages outside exception class
+# `TRY003` - Avoid specifying messages outside exception class
 
 ## Why is it bad
 

--- a/docs/violations/TRY004.md
+++ b/docs/violations/TRY004.md
@@ -1,4 +1,4 @@
-# `TC004` - Prefer `TypeError` exception for invalid type
+# `TRY004` - Prefer `TypeError` exception for invalid type
 
 ## Why is it bad
 

--- a/docs/violations/TRY100.md
+++ b/docs/violations/TRY100.md
@@ -1,4 +1,4 @@
-# `TC100` - Don't check to continue, raise an exception instead
+# `TRY100` - Don't check to continue, raise an exception instead
 
 ## Why is it bad
 

--- a/docs/violations/TRY101.md
+++ b/docs/violations/TRY101.md
@@ -1,4 +1,4 @@
-# `TC101` - Too many try blocks in your function
+# `TRY101` - Too many try blocks in your function
 
 ## Why is it bad
 

--- a/docs/violations/TRY200.md
+++ b/docs/violations/TRY200.md
@@ -1,4 +1,4 @@
-# `TC200` - Use 'raise from' to specify cause
+# `TRY200` - Use 'raise from' to specify cause
 
 ## Why is it bad
 

--- a/docs/violations/TRY201.md
+++ b/docs/violations/TRY201.md
@@ -1,4 +1,4 @@
-# `TC201` - Verbose reraise
+# `TRY201` - Verbose reraise
 
 ## Why is it bad
 

--- a/docs/violations/TRY202.md
+++ b/docs/violations/TRY202.md
@@ -1,4 +1,4 @@
-# `TC202` - Verbose reraise
+# `TRY202` - Verbose reraise
 
 ## Why is it bad
 

--- a/docs/violations/TRY300.md
+++ b/docs/violations/TRY300.md
@@ -1,4 +1,4 @@
-# `TC300` - Consider `else` block
+# `TRY300` - Consider `else` block
 
 ## Why is it bad
 

--- a/docs/violations/TRY301.md
+++ b/docs/violations/TRY301.md
@@ -1,4 +1,4 @@
-# `TC301` - `raise` within `try`
+# `TRY301` - `raise` within `try`
 
 ## Why is it bad
 

--- a/docs/violations/TRY400.md
+++ b/docs/violations/TRY400.md
@@ -1,4 +1,4 @@
-# `TC400` - Use logging '.exception' instead of 'error'
+# `TRY400` - Use logging '.exception' instead of 'error'
 
 ## Why is it bad
 

--- a/docs/violations/TRY401.md
+++ b/docs/violations/TRY401.md
@@ -1,4 +1,4 @@
-# `TC401` - Do not log the exception object
+# `TRY401` - Do not log the exception object
 
 ## Why is it bad
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 tryceratops = 'tryceratops.__main__:main'
 
 [tool.poetry.plugins."flake8.extension"]
-TC = "tryceratops.flake_plugin:TryceratopsAdapterPlugin"
+TRY = "tryceratops.flake_plugin:TryceratopsAdapterPlugin"
 
 [tool.poetry.urls]
 "Changelog" = "https://github.com/guilatrova/tryceratops/blob/main/CHANGELOG.md"

--- a/src/tests/files_test.py
+++ b/src/tests/files_test.py
@@ -36,13 +36,13 @@ def test_parse_specific_code_line():
 
     first, second, third = ignore_lines
     assert first.line == 13
-    assert first.code == ["TC202"]
+    assert first.code == ["TRY202"]
 
     assert second.line == 21
-    assert second.code == ["TC202", "TC200", "TC201"]
+    assert second.code == ["TRY202", "TRY200", "TRY201"]
 
     assert third.line == 30
-    assert third.code == ["TC101"]
+    assert third.code == ["TRY101"]
 
 
 def test_parse_ignore_file():
@@ -61,56 +61,56 @@ def test_parse_ignore_file():
 def test_entity_ignores_all():
     ignore = IgnoreViolation(10)
 
-    assert ignore.is_ignoring(10, "TC200") is True
-    assert ignore.is_ignoring(10, "TC100") is True
-    assert ignore.is_ignoring(10, "TC300") is True
+    assert ignore.is_ignoring(10, "TRY200") is True
+    assert ignore.is_ignoring(10, "TRY100") is True
+    assert ignore.is_ignoring(10, "TRY300") is True
     assert ignore.is_ignoring(10, "anything") is True
 
-    assert ignore.is_ignoring(12, "TC200") is False
-    assert ignore.is_ignoring(12, "TC100") is False
-    assert ignore.is_ignoring(12, "TC300") is False
+    assert ignore.is_ignoring(12, "TRY200") is False
+    assert ignore.is_ignoring(12, "TRY100") is False
+    assert ignore.is_ignoring(12, "TRY300") is False
     assert ignore.is_ignoring(12, "anything") is False
 
 
 def test_entity_ignores_specific():
-    ignore = IgnoreViolation(10, ["TC200", "TC101"])
+    ignore = IgnoreViolation(10, ["TRY200", "TRY101"])
 
-    assert ignore.is_ignoring(10, "TC200") is True
-    assert ignore.is_ignoring(10, "TC101") is True
-    assert ignore.is_ignoring(10, "TC100") is False
-    assert ignore.is_ignoring(10, "TC300") is False
+    assert ignore.is_ignoring(10, "TRY200") is True
+    assert ignore.is_ignoring(10, "TRY101") is True
+    assert ignore.is_ignoring(10, "TRY100") is False
+    assert ignore.is_ignoring(10, "TRY300") is False
     assert ignore.is_ignoring(10, "anything") is False
 
 
 def test_entity_ignore_all_whole_file():
     ignore = IgnoreViolation(1)
 
-    assert ignore.is_ignoring(10, "TC200") is True
-    assert ignore.is_ignoring(10, "TC100") is True
-    assert ignore.is_ignoring(10, "TC300") is True
+    assert ignore.is_ignoring(10, "TRY200") is True
+    assert ignore.is_ignoring(10, "TRY100") is True
+    assert ignore.is_ignoring(10, "TRY300") is True
     assert ignore.is_ignoring(10, "anything") is True
 
     # Still true
-    assert ignore.is_ignoring(12, "TC200") is True
-    assert ignore.is_ignoring(12, "TC100") is True
-    assert ignore.is_ignoring(12, "TC300") is True
+    assert ignore.is_ignoring(12, "TRY200") is True
+    assert ignore.is_ignoring(12, "TRY100") is True
+    assert ignore.is_ignoring(12, "TRY300") is True
     assert ignore.is_ignoring(12, "anything") is True
 
 
 def test_entity_ignore_specific_whole_file():
-    ignore = IgnoreViolation(1, ["TC200", "TC101"])
+    ignore = IgnoreViolation(1, ["TRY200", "TRY101"])
 
     # Any line
-    assert ignore.is_ignoring(10, "TC200") is True
-    assert ignore.is_ignoring(10, "TC101") is True
-    assert ignore.is_ignoring(20, "TC200") is True
-    assert ignore.is_ignoring(20, "TC101") is True
-    assert ignore.is_ignoring(30, "TC200") is True
-    assert ignore.is_ignoring(30, "TC101") is True
+    assert ignore.is_ignoring(10, "TRY200") is True
+    assert ignore.is_ignoring(10, "TRY101") is True
+    assert ignore.is_ignoring(20, "TRY200") is True
+    assert ignore.is_ignoring(20, "TRY101") is True
+    assert ignore.is_ignoring(30, "TRY200") is True
+    assert ignore.is_ignoring(30, "TRY101") is True
 
     # Any other violation
-    assert ignore.is_ignoring(10, "TC300") is False
+    assert ignore.is_ignoring(10, "TRY300") is False
     assert ignore.is_ignoring(10, "anything") is False
-    assert ignore.is_ignoring(20, "TC002") is False
-    assert ignore.is_ignoring(30, "TC301") is False
+    assert ignore.is_ignoring(20, "TRY002") is False
+    assert ignore.is_ignoring(30, "TRY301") is False
     assert ignore.is_ignoring(30, "anything") is False

--- a/src/tests/samples/ignore_comments/ignore_line_specific.py
+++ b/src/tests/samples/ignore_comments/ignore_line_specific.py
@@ -10,7 +10,7 @@ def verbose_reraise_1():
     except (NotImplementedError, ValueError) as ex:
         raise
     except Exception as ex:
-        raise ex  # noqa: TC202
+        raise ex  # noqa: TRY202
 
 
 def verbose_reraise_2():
@@ -18,7 +18,7 @@ def verbose_reraise_2():
         a = 1
     except Exception as ex:
         if a == 1:
-            raise ex  # noqa: TC202, TC200, TC201 I want to skip
+            raise ex  # noqa: TRY202, TRY200, TRY201 I want to skip
 
 
 def too_many_try():
@@ -27,7 +27,7 @@ def too_many_try():
     except Exception:
         raise
 
-    try:  # noqa:TC101 this is not a big deal
+    try:  # noqa:TRY101 this is not a big deal
         b = 2
     except Exception:
         raise

--- a/src/tryceratops/__main__.py
+++ b/src/tryceratops/__main__.py
@@ -22,7 +22,7 @@ AUTOFIX_FLAG_OPTION = dict(
 )
 IGNORE_OPTION = dict(
     multiple=True,
-    help="A violation to be ignored. e.g. -i TC200 -i TC201",
+    help="A violation to be ignored. e.g. -i TRY200 -i TRY201",
     type=click.Choice(CODE_CHOICES),
 )
 EXCLUDE_OPTION = dict(multiple=True, help="A dir to be excluded. e.g. -x tests/ -x fixtures/")

--- a/src/tryceratops/files/parser.py
+++ b/src/tryceratops/files/parser.py
@@ -6,7 +6,7 @@ from typing import Generator, Iterable, TextIO, Tuple
 from tryceratops.filters import FileFilter, IgnoreViolation
 
 IGNORE_TRYCERATOPS_TOKEN = "noqa"
-IGNORE_TOKEN_PATT = r"noqa(: ?((TC\d{3},? ?)+))?"
+IGNORE_TOKEN_PATT = r"noqa(: ?((TRY\d{3},? ?)+))?"
 
 
 def _build_ignore_line(match: re.Match, location: Tuple[int, int]) -> IgnoreViolation:

--- a/src/tryceratops/types.py
+++ b/src/tryceratops/types.py
@@ -11,7 +11,7 @@ class PyprojectConfig(TypedDict):
     """
     Represents the expected pyproject config to be loaded
         exclude: a list of path patterns to be excluded e.g. [/tests, /fixtures]
-        ignore: a list of violations to be completely ignored e.g. [TC002, TC300]
+        ignore: a list of violations to be completely ignored e.g. [TRY002, TRY300]
         experimental: whether to enable experimental analyzers
     """
 

--- a/src/tryceratops/violations/codes.py
+++ b/src/tryceratops/violations/codes.py
@@ -1,44 +1,44 @@
-# TC0xx - Exceptions
-RAISE_VANILLA_CLASS = ("TC002", "Create your own exception")
+# TRY0xx - Exceptions
+RAISE_VANILLA_CLASS = ("TRY002", "Create your own exception")
 RAISE_VANILLA_ARGS = (
-    "TC003",
+    "TRY003",
     "Avoid specifying long messages outside the exception class",
 )
-PREFER_TYPE_ERROR = ("TC004", "Prefer TypeError exception for invalid type")
+PREFER_TYPE_ERROR = ("TRY004", "Prefer TypeError exception for invalid type")
 
-# TC1xx - General
+# TRY1xx - General
 CHECK_TO_CONTINUE = (
-    "TC100",
+    "TRY100",
     "Don't check to continue, make callable '{}' raise a exception instead",
 )
-TOO_MANY_TRY = ("TC101", "Too many try blocks in your function")
+TOO_MANY_TRY = ("TRY101", "Too many try blocks in your function")
 
-# TC2xx - Except
-RERAISE_NO_CAUSE = ("TC200", "Use 'raise from' to specify exception cause")
+# TRY2xx - Except
+RERAISE_NO_CAUSE = ("TRY200", "Use 'raise from' to specify exception cause")
 VERBOSE_RERAISE = (
-    "TC201",
+    "TRY201",
     "Simply use 'raise' without specifying exception object again",
 )
-IGNORING_EXCEPTION = ("TC202", "You're ignoring a broad exception without even logging")
+IGNORING_EXCEPTION = ("TRY202", "You're ignoring a broad exception without even logging")
 
-# TC3xx - Try
-CONSIDER_ELSE = ("TC300", "Consider moving this statement to an 'else' block")
-RAISE_WITHIN_TRY = ("TC301", "Abstract raise to an inner function")
+# TRY3xx - Try
+CONSIDER_ELSE = ("TRY300", "Consider moving this statement to an 'else' block")
+RAISE_WITHIN_TRY = ("TRY301", "Abstract raise to an inner function")
 
-# TC4xx - Logging
-USE_LOGGING_EXCEPTION = ("TC400", "Use logging '.exception' instead of '.error'")
-VERBOSE_LOG_MESSAGE = ("TC401", "Do not log exception object, give context instead")
+# TRY4xx - Logging
+USE_LOGGING_EXCEPTION = ("TRY400", "Use logging '.exception' instead of '.error'")
+VERBOSE_LOG_MESSAGE = ("TRY401", "Do not log exception object, give context instead")
 
 CODE_CHOICES = {
-    "TC002",
-    "TC003",
-    "TC100",
-    "TC101",
-    "TC200",
-    "TC201",
-    "TC202",
-    "TC300",
-    "TC301",
-    "TC400",
-    "TC401",
+    "TRY002",
+    "TRY003",
+    "TRY100",
+    "TRY101",
+    "TRY200",
+    "TRY201",
+    "TRY202",
+    "TRY300",
+    "TRY301",
+    "TRY400",
+    "TRY401",
 }


### PR DESCRIPTION
Hi!
Thanks for great project.

As was mentioned in https://github.com/guilatrova/tryceratops/issues/41, there is a flake8 code clash between your project and `flake8-type-checkin`. When used together within single project `tryceratops` completely disables `flake8-type-checkin`. Flake8 doesn't give any warning about this, which leads to bad code passing linters silently.
