### PR TITLE
chore: only depend on `tomli` on `Python < 3.11`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -449,8 +449,11 @@ name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = "*"
-files = []
+python-versions = ">=3.7"
+files = [
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
+]
 
 [[package]]
 name = "dotty-dict"
@@ -1159,7 +1162,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1474,4 +1476,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "4a422dc1e8fe6ffaa2b8c6f9057bc68259b3a8476c4dabcb6c3d14c82b3d9935"
+content-hash = "2c4bace7739060e40f37f23e956f0ed38ba4d975f025984dd4dba0d78fa14387"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build_command = "pip install poetry && poetry build"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 click = ">=7"
-tomli = "^2.0.1"
+tomli = { version = "^2.0.1", python = "<3.11" }
 rich = ">=10.14.0"
 typing-extensions = { version = ">=4.5.0", python = "<3.11" }
 

--- a/src/tryceratops/files/discovery.py
+++ b/src/tryceratops/files/discovery.py
@@ -1,5 +1,5 @@
 import logging
-import tomli as tomllib
+import sys
 from dataclasses import dataclass
 from os import listdir
 from os.path import isdir, isfile, join
@@ -9,6 +9,11 @@ from typing import Generator, Iterable, List, Optional, Sequence
 from tryceratops.parsing_types import ParsedFileType, PyprojectConfig
 
 from .parser import parse_file
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Since Python >= 3.11 includes `tomllib` with an API that is identical to `tomli` (see
https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer), we can conditionally require `tomli` on Python < 3.11 only.