### PR TITLE
fix: allow f-string to trigger TRY003

### DIFF
--- a/src/tests/analyzers_call_test.py
+++ b/src/tests/analyzers_call_test.py
@@ -54,7 +54,7 @@ def test_raise_long_args():
 
     assert_args(17, 8, first)
     assert_args(23, 8, second)
-    assert_args(27, 8, third)
+    assert_args(29, 8, third)
 
 
 def test_check_continue():

--- a/src/tests/analyzers_call_test.py
+++ b/src/tests/analyzers_call_test.py
@@ -49,10 +49,11 @@ def test_raise_long_args():
 
     violations = analyzer.check(tree, "filename")
 
-    assert len(violations) == 1
-    violation, *_ = violations
+    assert len(violations) == 2
+    first, second = violations
 
-    assert_args(17, 8, violation)
+    assert_args(17, 8, first)
+    assert_args(23, 8, second)
 
 
 def test_check_continue():

--- a/src/tests/analyzers_call_test.py
+++ b/src/tests/analyzers_call_test.py
@@ -49,11 +49,12 @@ def test_raise_long_args():
 
     violations = analyzer.check(tree, "filename")
 
-    assert len(violations) == 2
-    first, second = violations
+    assert len(violations) == 3
+    first, second, third = violations
 
     assert_args(17, 8, first)
     assert_args(23, 8, second)
+    assert_args(27, 8, third)
 
 
 def test_check_continue():

--- a/src/tests/samples/violations/call_raise_long_str.py
+++ b/src/tests/samples/violations/call_raise_long_str.py
@@ -21,11 +21,13 @@ def func():
         raise CustomException("its_code_not_message")  # This is acceptable
     elif a == 4:
         raise CustomException(f"long message with f-string {a}")
-    # elif a == 5:
-    #     raise CustomException(f"code_{a}")  # TODO: This should be acceptable!
+    elif a == 5:
+        raise CustomException(f"code_{a}")
     elif a == 6:
-        raise CustomException("long message number %s", a)
+        raise CustomException(f"code_{' ' + str(a)}")  # TODO: This should not be acceptable!
     elif a == 7:
+        raise CustomException("long message number %s", a)
+    elif a == 8:
         raise CustomException("code_message_number_%s", a)  # This is acceptable
 
 

--- a/src/tests/samples/violations/call_raise_long_str.py
+++ b/src/tests/samples/violations/call_raise_long_str.py
@@ -20,7 +20,13 @@ def func():
     elif a == 3:
         raise CustomException("its_code_not_message")  # This is acceptable
     elif a == 4:
-        raise CustomException(f"A long message in the f-string number {a}")
+        raise CustomException(f"long message with f-string {a}")
+    # elif a == 5:
+    #     raise CustomException(f"code_{a}")  # TODO: This should be acceptable!
+    elif a == 6:
+        raise CustomException("long message number %s", a)
+    elif a == 7:
+        raise CustomException("code_message_number_%s", a)  # This is acceptable
 
 
 def ignore():

--- a/src/tests/samples/violations/call_raise_long_str.py
+++ b/src/tests/samples/violations/call_raise_long_str.py
@@ -19,6 +19,8 @@ def func():
         raise CustomException("Short")  # This is acceptable
     elif a == 3:
         raise CustomException("its_code_not_message")  # This is acceptable
+    elif a == 4:
+        raise CustomException(f"A long message in the f-string number {a}")
 
 
 def ignore():

--- a/src/tryceratops/analyzers/call.py
+++ b/src/tryceratops/analyzers/call.py
@@ -42,6 +42,10 @@ class CallRaiseLongArgsAnalyzer(BaseRaiseCallableAnalyzer):
             if is_constant_str and WHITESPACE in first_arg.value:  # type: ignore
                 self._mark_violation(node)
 
+            is_constant_fstr = isinstance(first_arg, ast.JoinedStr)
+            if is_constant_fstr:
+                self._mark_violation(node)
+
 
 class CallAvoidCheckingToContinueAnalyzer(BaseAnalyzer):
     EXPERIMENTAL = True

--- a/src/tryceratops/analyzers/call.py
+++ b/src/tryceratops/analyzers/call.py
@@ -34,17 +34,18 @@ class CallRaiseLongArgsAnalyzer(BaseRaiseCallableAnalyzer):
     def _check_raise_callable(self, node: ast.Raise, exc: ast.Call, func: ast.Name) -> None:
         if len(exc.args):
             first_arg, *_ = exc.args
-            is_constant_str = isinstance(first_arg, ast.Constant) and isinstance(
-                first_arg.value, str
-            )
-
             WHITESPACE = " "
-            if is_constant_str and WHITESPACE in first_arg.value:  # type: ignore
-                self._mark_violation(node)
 
-            is_constant_fstr = isinstance(first_arg, ast.JoinedStr)
-            if is_constant_fstr:
-                self._mark_violation(node)
+            if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+                if WHITESPACE in first_arg.value:
+                    self._mark_violation(node)
+
+            if isinstance(first_arg, ast.JoinedStr):
+                for f_string_part in first_arg.values:
+                    if isinstance(f_string_part, ast.Constant):
+                        if isinstance(f_string_part.value, str):
+                            if WHITESPACE in f_string_part.value:
+                                self._mark_violation(node)
 
 
 class CallAvoidCheckingToContinueAnalyzer(BaseAnalyzer):


### PR DESCRIPTION
Hello, and thank you for this package!

I stumble across the issue https://github.com/guilatrova/tryceratops/issues/31 and may have a potential fix.
The problem was false negative for rule TRY003, _"Avoid specifying long messages outside the exception class"_, the root cause being the use of f-string in such messages.

The solution simply consists of checking whether the string is an f-string using `ast.JoinedStr`.

However, this fix is not perfect, as illustrated by the following example:

```python
    elif a == 5:
        raise CustomException(f"code_{a}")  # This should be acceptable
```
This code triggers TRY003 with the fix, but it should be acceptable since there are no whitespaces, like in the existing test

```python
    elif a == 3:
        raise CustomException("its_code_not_message")  # This is acceptable
```
The challenge is that, to my knowledge, there is no way to determine the content of an f-string during parsing without evaluating it first. It is probably beyond the scope of static analysis.

I think it is related to why Google discourages the use of f-string for logging [in their styleguide](https://google.github.io/styleguide/pyguide.html#3101-logging). If f-strings are considered a bad practice for exceptions as well,, it might be worth adding a new violation rule in Tryceratops specifically for them.

Please let me know if you have any feedback or suggestions for improving this fix. 
